### PR TITLE
Fix query param handling for excludeIngredients

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,7 +22,7 @@ app.get("/", function (req, res) {
   }
 
   if (!!excludeIngredients) {
-    parsedIngredients = includeIngredients.split(",");
+    parsedIngredients = excludeIngredients.split(",");
     returnRecipes = filter.byExcludedIngredients(returnRecipes, parsedIngredients);
   }
 


### PR DESCRIPTION
#### Summary 

- Updates `excludeIngredient` query param logic
  - API calls containing only an `excludeIngredient` query param were previously failing (`500` error)