### PR TITLE
pin node version to 12.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guac-is-extra",
   "engines": {
-    "node": ">=12.13" 
+    "node": "12.13"
   },
   "version": "1.0.0",
   "description": "A simple API for fetching taco recipes",


### PR DESCRIPTION
The app is trying to deploy with Node 19 which isn't supported by our current stack. We could probably bump it but one thing at a time 😄